### PR TITLE
Tankmanager supports AI, bullets and mines no longer increase score on player hits

### DIFF
--- a/Assets/Bullet_Scripts/Bullet.cs
+++ b/Assets/Bullet_Scripts/Bullet.cs
@@ -65,16 +65,18 @@ public class Bullet : MonoBehaviour
                 if (collision.gameObject.GetComponent<TankManager>() != null)
                 {
                     collision.gameObject.GetComponent<TankManager>().Die();
-                    ++GameObject.Find("Tank " + playerWhoFired).GetComponent<TankManager>().score;
-                    Debug.Log("Tank " + playerWhoFired + " has hit " + collision.gameObject.name + ", and scored a point for themselves! Their score is now " + GameObject.Find("Tank " + playerWhoFired).GetComponent<TankManager>().score);
+                    //++GameObject.Find("Tank " + playerWhoFired).GetComponent<TankManager>().score;
+                    Debug.Log("Tank " + playerWhoFired + " has hit " + collision.gameObject.name + ", but won't have scored - this isn't PvP! Their score is still " + GameObject.Find("Tank " + playerWhoFired).GetComponent<TankManager>().score);
                 }
                 Die();
             }
             else
             {
-                collision.gameObject.GetComponent<TankManager>().Die();
-                --GameObject.Find("Tank " + playerWhoFired).GetComponent<TankManager>().score;
-                Debug.Log("Tank " + playerWhoFired + " has hit themselves, and lost a point. Their score is now " + GameObject.Find("Tank " + playerWhoFired).GetComponent<TankManager>().score + "... what an idiot!");
+
+                    collision.gameObject.GetComponent<TankManager>().Die();
+                    //--GameObject.Find("Tank " + playerWhoFired).GetComponent<TankManager>().score;
+                    Debug.Log("Tank " + playerWhoFired + " has hit themselves, and NOT lost a point. Their score is still " + GameObject.Find("Tank " + playerWhoFired).GetComponent<TankManager>().score + "... what an idiot!");
+                Die();
             }
             // bounce(collision);
 

--- a/Assets/Joe's Stuff/Tank.prefab
+++ b/Assets/Joe's Stuff/Tank.prefab
@@ -380,7 +380,7 @@ ParticleSystem:
   ringBufferLoopRange: {x: 0, y: 1}
   looping: 0
   prewarm: 0
-  playOnAwake: 1
+  playOnAwake: 0
   useUnscaledTime: 0
   autoRandomSeed: 1
   useRigidbodyForVelocity: 1
@@ -5418,6 +5418,11 @@ MonoBehaviour:
   dropSound: {fileID: 8300000, guid: f1709ab8b29d7744c9d1338060c5e632, type: 3}
   spawnPoints: []
   lifecounter: []
+  aiSprites:
+  - {fileID: 21300000, guid: 277a533295d1d2441a3dbec4243a2b8c, type: 3}
+  - {fileID: 21300000, guid: fa02cd1de512c4d408303becff1acb8b, type: 3}
+  - {fileID: 21300000, guid: 67f14ef2359b7a84c92b884339bd53ff, type: 3}
+  ai: 0
   hot: 0
 --- !u!114 &397371879313652475
 MonoBehaviour:
@@ -5449,7 +5454,7 @@ ParticleSystem:
   ringBufferLoopRange: {x: 0, y: 1}
   looping: 1
   prewarm: 0
-  playOnAwake: 1
+  playOnAwake: 0
   useUnscaledTime: 0
   autoRandomSeed: 1
   useRigidbodyForVelocity: 1
@@ -10526,6 +10531,10 @@ PrefabInstance:
     - target: {fileID: 5344174733521406568, guid: 67a861ab98ae09049bab768ab6f04df5, type: 3}
       propertyPath: m_Name
       value: DeathBoom
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846815698024921754, guid: 67a861ab98ae09049bab768ab6f04df5, type: 3}
+      propertyPath: playOnAwake
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 67a861ab98ae09049bab768ab6f04df5, type: 3}

--- a/Assets/Joe's Stuff/mine.cs
+++ b/Assets/Joe's Stuff/mine.cs
@@ -43,22 +43,22 @@ public class mine : MonoBehaviour
             switch (collision.gameObject.layer)
             {
                 case playerLayer:
-                    if (collision.gameObject.GetComponent<TankManager>() != null)
+                    //if (collision.gameObject.GetComponent<TankManager>() != null)
                     if (collision.gameObject.GetComponent<TankManager>() != null && collision.gameObject.GetComponent<TankManager>().player != player)
                     {
                         collision.gameObject.GetComponent<TankManager>().Die();
                         GetComponent<Collider2D>().enabled = false;
-                            ++GameObject.Find("Tank " + player).GetComponent<TankManager>().score;
-                            Debug.Log("Tank " + player + " has mined another player, and scored a point. Their score is now " + GameObject.Find("Tank " + player).GetComponent<TankManager>().score + "!");
+                            //++GameObject.Find("Tank " + player).GetComponent<TankManager>().score;
+                            Debug.Log("Tank " + player + " has mined another player, and did not score a point. Their score is still " + GameObject.Find("Tank " + player).GetComponent<TankManager>().score + "!");
                             Destroy(gameObject);
                     }
                     else
                         {
                             collision.gameObject.GetComponent<TankManager>().Die();
-                            --GameObject.Find("Tank " + player).GetComponent<TankManager>().score;
+                            //--GameObject.Find("Tank " + player).GetComponent<TankManager>().score;
                             GetComponent<Collider2D>().enabled = false;
                             Debug.Log("A mine went off!");
-                            Debug.Log("Tank " + player + " has ran over their own mine, and lost a point. Their score is now " + GameObject.Find("Tank " + player).GetComponent<TankManager>().score + "... what an idiot!");
+                            Debug.Log("Tank " + player + " has ran over their own mine, and has not lost a point. Their score is still " + GameObject.Find("Tank " + player).GetComponent<TankManager>().score + "... what an idiot!");
                             Destroy(gameObject);
 
                         }
@@ -68,8 +68,9 @@ public class mine : MonoBehaviour
                     //if (collision.gameObject.GetComponent<TankManager>() != null && collision.gameObject.GetComponent<TankManager>().player != player)
                     {
                         GetComponent<Collider2D>().enabled = false;
+                        ++GameObject.Find("Tank " + player).GetComponent<TankManager>().score;
                         collision.gameObject.GetComponent<TankManager>().Die();
-                        Debug.Log("A mine went off!");
+                        Debug.Log("Tank " + player + " has mined an enemy, and scored a point. Their score is now " + GameObject.Find("Tank " + player).GetComponent<TankManager>().score + "!");
                         Destroy(gameObject);
                     }
                     break;


### PR DESCRIPTION
tankmanager disables life counter, respawns on AI spawnpoints and changes sprites to grey if the AI flag is set to true